### PR TITLE
Fixes issue #19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "uuid",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1342,6 +1343,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rustls-pemfile = "1"
 md5 = "0.7.0"
 lazy_static = "1.4.0"
 uuid = { version = "1.1.1", features = ["v4", "fast-rng"] }
+xml-rs = "0.8.4"
 
 [profile.release]
 lto = true

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use crate::auth::{generate_www_auth, valid_digest};
 use crate::{Args, BoxResult};
+use xml::escape::escape_str_pcdata;
 
 use async_walkdir::WalkDir;
 use async_zip::write::{EntryOptions, ZipFileWriter};
@@ -821,7 +822,10 @@ impl PathItem {
 <D:status>HTTP/1.1 200 OK</D:status>
 </D:propstat>
 </D:response>"#,
-                prefix, self.name, self.base_name, mtime
+                escape_str_pcdata(&prefix),
+                escape_str_pcdata(&self.name),
+                escape_str_pcdata(&self.base_name),
+                mtime
             ),
             PathType::File | PathType::SymlinkFile => format!(
                 r#"<D:response>
@@ -836,9 +840,9 @@ impl PathItem {
 <D:status>HTTP/1.1 200 OK</D:status>
 </D:propstat>
 </D:response>"#,
-                prefix,
-                self.name,
-                self.base_name,
+                escape_str_pcdata(&prefix),
+                escape_str_pcdata(&self.name),
+                escape_str_pcdata(&self.base_name),
                 self.size.unwrap_or_default(),
                 mtime
             ),


### PR DESCRIPTION
Filenames in a WebDAV response are now escaped with [xml](https://docs.rs/xml-rs/0.8.0/xml/index.html)::[escape](https://docs.rs/xml-rs/0.8.0/xml/escape/index.html)::[escape_str_pcdata](https://docs.rs/xml-rs/0.8.0/xml/escape/fn.escape_str_pcdata.html).

An excerpt from the new PROPFIND response, for example:
```xml
<!-- for the folder "/This & that" -->
<D:href>/This &amp; that</D:href>
```