### PR TITLE
fixed #23 filename xml escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "tokio-util",
  "urlencoding",
  "uuid",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1367,6 +1368,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ md5 = "0.7.0"
 lazy_static = "1.4.0"
 uuid = { version = "1.1.1", features = ["v4", "fast-rng"] }
 urlencoding = "2.1.0"
+xml-rs = "0.8"
 env_logger = { version = "0.9.0", default-features = false, features = ["humantime"] }
 log = "0.4.17"
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use crate::auth::{generate_www_auth, valid_digest};
 use crate::{encode_uri, Args, BoxResult};
+use xml::escape::escape_str_pcdata;
 
 use async_walkdir::WalkDir;
 use async_zip::write::{EntryOptions, ZipFileWriter};
@@ -822,8 +823,8 @@ impl PathItem {
 </D:propstat>
 </D:response>"#,
                 prefix,
-                encode_uri(&self.name),
-                urlencoding::encode(&self.base_name),
+                escape_str_pcdata(&self.name),
+                escape_str_pcdata(&self.base_name),
                 mtime
             ),
             PathType::File | PathType::SymlinkFile => format!(
@@ -840,8 +841,8 @@ impl PathItem {
 </D:propstat>
 </D:response>"#,
                 prefix,
-                encode_uri(&self.name),
-                urlencoding::encode(&self.base_name),
+                escape_str_pcdata(&self.name),
+                escape_str_pcdata(&self.base_name),
                 self.size.unwrap_or_default(),
                 mtime
             ),


### PR DESCRIPTION
gvfs/gio doesn't like percent-encoding. Everything is ok with xml-escaped text, though.