### PR TITLE
feat: path level access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,14 @@ For examples:
 ```
 duf -a /@admin:pass@* -a /ui@designer:pass1 -A
 ```
+- All files/folders are public to access/download.
+- Account `admin:pass` can upload/delete/download any files/folders.
+- Account `designer:pass1` can upload/delete/download any files/folders in the `ui` folder.
 
-All files/folders are public to access/download. Account `admin:pass` can upload/delete/download any files/folders, Account `designer:pass1` can upload/delete/download files/folders in the `ui` folder.
-
-Download a file with auth
+Curl with auth:
 
 ```
-curl --digest -u designer:pass1 http://127.0.0.1:5000/dist/path-to-file
+curl --digest -u designer:pass1 http://127.0.0.1:5000/ui/path-to-file
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ duf -a <path>@<readwrite>[@<readonly>]
 - `<readwrite>`: Account with readwrite permission, required
 - `<readonly>`: Account with readonly permission, optional
 
-> `*` as `<readonly>` means `<path>` is public, everyone can acess/download it.
+> `*` as `<readonly>` means `<path>` is public, everyone can access/download it.
 
-For examples:
+For example:
 
 ```
 duf -a /@admin:pass@* -a /ui@designer:pass1 -A

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Duf is a simple file server. Support static serve, search, upload, webdav...
 - Upload files and folders (Drag & Drop)
 - Search files
 - Partial responses (Parallel/Resume download)
-- Authentication
+- Path level access control
 - Support https
 - Support webdav
 - Easy to use with curl
@@ -88,12 +88,6 @@ Listen on a specific port
 duf -p 80
 ```
 
-Protect with authentication
-
-```
-duf -a admin:admin
-```
-
 For a single page application (SPA)
 
 ```
@@ -110,25 +104,57 @@ duf --tls-cert my.crt --tls-key my.key
 
 Download a file
 ```
-curl http://127.0.0.1:5000/some-file
+curl http://127.0.0.1:5000/path-to-file
 ```
 
 Download a folder as zip file
 
 ```
-curl -o some-folder.zip http://127.0.0.1:5000/some-folder?zip
+curl -o path-to-folder.zip http://127.0.0.1:5000/path-to-folder?zip
 ```
 
 Upload a file
 
 ```
-curl --upload-file some-file http://127.0.0.1:5000/some-file
+curl --upload-file path-to-file http://127.0.0.1:5000/path-to-file
 ```
 
 Delete a file/folder
 
 ```
-curl -X DELETE http://127.0.0.1:5000/some-file
+curl -X DELETE http://127.0.0.1:5000/path-to-file
+```
+
+
+## Auth
+
+Duf supports path level access control through option `--auth`/`-a`.
+
+Grammar rule:
+
+```
+<path>@<readwrite>[@<readonly>]
+```
+
+- `<path>`: Path to protected
+- `<readwrite>`: Account with readwrite permission
+- `<readonly>`: Account with readonly permission
+
+> If `<readonly>` is `*`, means `<path>` is public, everyone can acess/download it.
+
+
+For examples:
+
+```
+duf -a /@admin:pass@* -a /ui@designer:pass1 -A
+```
+
+All files/folders are public to access/download. Account `admin:pass` can upload/delete/download any files/folders, Account `designer:pass1` can upload/delete/download files/folders in the `ui` folder.
+
+Download a file with auth
+
+```
+curl --digest -u designer:pass1 http://127.0.0.1:5000/dist/path-to-file
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -125,23 +125,21 @@ Delete a file/folder
 curl -X DELETE http://127.0.0.1:5000/path-to-file
 ```
 
-
 ## Auth
 
-Duf supports path level access control through option `--auth`/`-a`.
+<details>
 
-Grammar rule:
+<summary>Duf supports path level access control with --auth/-a option.</summary>
 
 ```
-<path>@<readwrite>[@<readonly>]
+duf -a <path>@<readwrite>[@<readonly>]
 ```
 
 - `<path>`: Path to protected
-- `<readwrite>`: Account with readwrite permission
-- `<readonly>`: Account with readonly permission
+- `<readwrite>`: Account with readwrite permission, required
+- `<readonly>`: Account with readonly permission, optional
 
-> If `<readonly>` is `*`, means `<path>` is public, everyone can acess/download it.
-
+> `*` as `<readonly>` means `<path>` is public, everyone can acess/download it.
 
 For examples:
 
@@ -157,6 +155,8 @@ Curl with auth:
 ```
 curl --digest -u designer:pass1 http://127.0.0.1:5000/ui/path-to-file
 ```
+
+</details>
 
 ## License
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod auth;
 mod server;
 mod streamer;
 mod tls;
+mod utils;
 
 #[macro_use]
 extern crate log;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,12 @@
+use std::borrow::Cow;
+
+pub fn encode_uri(v: &str) -> String {
+    let parts: Vec<_> = v.split('/').map(urlencoding::encode).collect();
+    parts.join("/")
+}
+
+pub fn decode_uri(v: &str) -> Option<Cow<str>> {
+    percent_encoding::percent_decode(v.as_bytes())
+        .decode_utf8()
+        .ok()
+}

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -6,7 +6,7 @@ use fixtures::{server, Error, TestServer};
 use rstest::rstest;
 
 #[rstest]
-fn no_auth(#[with(&["--auth", "user:pass", "-A"])] server: TestServer) -> Result<(), Error> {
+fn no_auth(#[with(&["--auth", "/@user:pass", "-A"])] server: TestServer) -> Result<(), Error> {
     let resp = reqwest::blocking::get(server.url())?;
     assert_eq!(resp.status(), 401);
     assert!(resp.headers().contains_key("www-authenticate"));
@@ -17,7 +17,7 @@ fn no_auth(#[with(&["--auth", "user:pass", "-A"])] server: TestServer) -> Result
 }
 
 #[rstest]
-fn auth(#[with(&["--auth", "user:pass", "-A"])] server: TestServer) -> Result<(), Error> {
+fn auth(#[with(&["--auth", "/@user:pass", "-A"])] server: TestServer) -> Result<(), Error> {
     let url = format!("{}file1", server.url());
     let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
     assert_eq!(resp.status(), 401);
@@ -29,10 +29,54 @@ fn auth(#[with(&["--auth", "user:pass", "-A"])] server: TestServer) -> Result<()
 }
 
 #[rstest]
-fn auth_skip_access(
-    #[with(&["--auth", "user:pass", "--no-auth-access"])] server: TestServer,
-) -> Result<(), Error> {
+fn auth_skip(#[with(&["--auth", "/@user:pass@*"])] server: TestServer) -> Result<(), Error> {
     let resp = reqwest::blocking::get(server.url())?;
+    assert_eq!(resp.status(), 200);
+    Ok(())
+}
+
+#[rstest]
+fn auth_readonly(
+    #[with(&["--auth", "/@user:pass@user2:pass2", "-A"])] server: TestServer,
+) -> Result<(), Error> {
+    let url = format!("{}index.html", server.url());
+    let resp = fetch!(b"GET", &url).send()?;
+    assert_eq!(resp.status(), 401);
+    let resp = fetch!(b"GET", &url).send_with_digest_auth("user2", "pass2")?;
+    assert_eq!(resp.status(), 200);
+    let url = format!("{}file1", server.url());
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .send_with_digest_auth("user2", "pass2")?;
+    assert_eq!(resp.status(), 401);
+    Ok(())
+}
+
+#[rstest]
+fn auth_nest(
+    #[with(&["--auth", "/@user:pass@user2:pass2", "--auth", "/dira@user3:pass3", "-A"])]
+    server: TestServer,
+) -> Result<(), Error> {
+    let url = format!("{}dira/file1", server.url());
+    let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
+    assert_eq!(resp.status(), 401);
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .send_with_digest_auth("user3", "pass3")?;
+    assert_eq!(resp.status(), 201);
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .send_with_digest_auth("user", "pass")?;
+    assert_eq!(resp.status(), 201);
+    Ok(())
+}
+
+#[rstest]
+fn auth_nest_share(
+    #[with(&["--auth", "/@user:pass@*", "--auth", "/dira@user3:pass3", "-A"])] server: TestServer,
+) -> Result<(), Error> {
+    let url = format!("{}index.html", server.url());
+    let resp = fetch!(b"GET", &url).send()?;
     assert_eq!(resp.status(), 200);
     Ok(())
 }


### PR DESCRIPTION
Duf supports path level access control through option `--auth`/`-a`.

Grammar rule:

```
<path>@<readwrite>[@<readonly>]
```

- `<path>`: Path to protected
- `<readwrite>`: Account with readwrite permission
- `<readonly>`: Account with readonly permission

> If `<readonly>` is `*`, means `<path>` is public, everyone can acess/download it.


BREAKING CHANGE: `--auth` is changed, `--no-auth-access` is removed